### PR TITLE
Adding open/read timeout as options.

### DIFF
--- a/lib/paypal_nvp.rb
+++ b/lib/paypal_nvp.rb
@@ -7,6 +7,9 @@ class PaypalNVP
     base.extend ClassMethods
   end
 
+  DEFAULT_OPEN_TIMEOUT = 60
+  DEFAULT_READ_TIMEOUT = 60
+
   def initialize(sandbox = false, extras = {})
     type = sandbox ? "sandbox" : "live"
     config = YAML.load_file("#{Rails.root}/config/paypal.yml") rescue nil
@@ -35,8 +38,8 @@ class PaypalNVP
     end
 
     # If network timeout is not set above, we simply default both of them to 60s
-    @open_timeout ||= 60
-    @read_timeout ||= 60
+    @open_timeout ||= DEFAULT_OPEN_TIMEOUT
+    @read_timeout ||= DEFAULT_READ_TIMEOUT
 
     @extras = extras
     @rootCA = @rootCA || '/etc/ssl/certs'

--- a/lib/paypal_nvp.rb
+++ b/lib/paypal_nvp.rb
@@ -22,26 +22,19 @@ class PaypalNVP
       @pass = config[type]["pass"]
       @cert = config[type]["cert"]
       @rootCA = config[type]["rootca"]
+      @open_timeout = config[type]["open_timeout"]
+      @read_timeout = config[type]["read_timeout"]
     else
       @url  = extras[:url]
       @user = extras[:user]
       @pass = extras[:pass]
       @cert = extras[:cert]
       @rootCA = extras[:rootca]
+      @open_timeout = extras.delete(:open_timeout)
+      @read_timeout = extras.delete(:read_timeout)
     end
     @extras = extras
     @rootCA = @rootCA || '/etc/ssl/certs'
-
-
-    if config
-      # Get the timeout options from the config
-      @open_timeout = config[type]["open_timeout"]
-      @read_timeout = config[type]["read_timeout"]
-    else
-      # Get the timeout options from the extra parameter
-      @open_timeout = extras[:open_timeout]
-      @read_timeout = extras[:read_timeout]
-    end
   end
 
   def call_paypal(data)

--- a/lib/paypal_nvp.rb
+++ b/lib/paypal_nvp.rb
@@ -7,7 +7,7 @@ class PaypalNVP
     base.extend ClassMethods
   end
 
-  DEFAULT_OPEN_TIMEOUT = 60
+  DEFAULT_OPEN_TIMEOUT = nil
   DEFAULT_READ_TIMEOUT = 60
 
   def initialize(sandbox = false, extras = {})
@@ -37,7 +37,7 @@ class PaypalNVP
       @read_timeout = extras.delete(:read_timeout)
     end
 
-    # If network timeout is not set above, we simply default both of them to 60s
+    # If network timeout is not set above, we simply default both of them to default values
     @open_timeout ||= DEFAULT_OPEN_TIMEOUT
     @read_timeout ||= DEFAULT_READ_TIMEOUT
 

--- a/lib/paypal_nvp.rb
+++ b/lib/paypal_nvp.rb
@@ -33,6 +33,11 @@ class PaypalNVP
       @open_timeout = extras.delete(:open_timeout)
       @read_timeout = extras.delete(:read_timeout)
     end
+
+    # If network timeout is not set above, we simply default both of them to 60s
+    @open_timeout ||= 60
+    @read_timeout ||= 60
+
     @extras = extras
     @rootCA = @rootCA || '/etc/ssl/certs'
   end


### PR DESCRIPTION
Added open/read timeout as options, so we can pass them into `Net::HTTP` client to do networking level timeout.
