### PR TITLE
Version 0.3.0.freeagent.1

### DIFF
--- a/paypal_nvp.gemspec
+++ b/paypal_nvp.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{paypal_nvp}
-  s.version = "0.3.0"
+  s.version = "0.3.0.freeagent.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = ["Olivier BONNAURE - solisoft"]


### PR DESCRIPTION
Use the freeagent pre-release tag as this is a gem forked from upstream rubygem.