### PR TITLE
Use URI::DEFAULT_PARSER.escape over URI.escape

### DIFF
--- a/lib/paypal_nvp.rb
+++ b/lib/paypal_nvp.rb
@@ -63,7 +63,7 @@ class PaypalNVP
     params.merge!(data)
     qs = []
     params.each do |key, value|
-      qs << "#{key.to_s.upcase}=#{URI.escape(value.to_s, /\+/)}"
+      qs << "#{key.to_s.upcase}=#{URI::DEFAULT_PARSER.escape(value.to_s, /\+/)}"
     end
     qs = "#{qs * "&"}"
 

--- a/paypal_nvp.gemspec
+++ b/paypal_nvp.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{paypal_nvp}
-  s.version = "0.3.0.freeagent.1"
+  s.version = "0.3.0.freeagent.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = ["Olivier BONNAURE - solisoft"]

--- a/paypal_nvp.gemspec
+++ b/paypal_nvp.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.7.2}
   s.summary = %q{Paypal NVP API Class.}
 
-  s.metadata["allowed_push_host"] = "http://rubygems.pkg.github.com/fac"
+  s.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com/fac"
 
   s.add_development_dependency "bundler", "~> 2.0"
   s.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
Use the `URI:DEFAULT_PARSER.escape` method over the now removed `URL.escape` method.